### PR TITLE
passing _wire instance to _magSensor as parameter.

### DIFF
--- a/Adafruit_LSM9DS1.cpp
+++ b/Adafruit_LSM9DS1.cpp
@@ -130,7 +130,7 @@ Adafruit_LSM9DS1::Adafruit_LSM9DS1(int8_t sclk, int8_t smiso, int8_t smosi,
 bool Adafruit_LSM9DS1::begin() {
   if (_i2c) {
     _wire->begin();
-    if (!_magSensor.begin_I2C(LSM9DS1_ADDRESS_MAG)) {
+    if (!_magSensor.begin_I2C(LSM9DS1_ADDRESS_MAG, _wire)) {
       return false;
     }
   } else if (_clk == -1) {


### PR DESCRIPTION
In Reference to Issue #12 
Pass the _wire instance to _magSensors, so if the Adafruit_LSM9DS1 is create for an other wire (e.g. the internal LSM9DS1 for the Arduino Nano 33 BLE), the _magSensors has the right Wire instance too.

Please let me know, if there are any issues.