### PR TITLE
Configure accelerometer's data rate

### DIFF
--- a/Adafruit_LSM9DS1.cpp
+++ b/Adafruit_LSM9DS1.cpp
@@ -180,7 +180,7 @@ bool Adafruit_LSM9DS1::begin() {
   _magSensor.setOperationMode(LIS3MDL_CONTINUOUSMODE);
 
   // Set default ranges for the various sensors
-  setupAccel(LSM9DS1_ACCELRANGE_2G);
+  setupAccel(LSM9DS1_ACCELRANGE_2G, LSM9DS1_ACCELDATARATE_10HZ);
   setupMag(LSM9DS1_MAGGAIN_4GAUSS);
   setupGyro(LSM9DS1_GYROSCALE_245DPS);
 
@@ -301,10 +301,10 @@ void Adafruit_LSM9DS1::readTemp() {
     LSM9DS1_ACCELRANGE_8G, LSM9DS1_ACCELRANGE_16G
 */
 /**************************************************************************/
-void Adafruit_LSM9DS1::setupAccel(lsm9ds1AccelRange_t range) {
+void Adafruit_LSM9DS1::setupAccel(lsm9ds1AccelRange_t range, lsm9ds1AccelDataRate_t rate) {
   uint8_t reg = read8(XGTYPE, LSM9DS1_REGISTER_CTRL_REG6_XL);
-  reg &= ~(0b00011000);
-  reg |= range;
+  reg &= ~(0b11111000);
+  reg |= range | rate;
   // Serial.println("set range: ");
   write8(XGTYPE, LSM9DS1_REGISTER_CTRL_REG6_XL, reg);
 

--- a/Adafruit_LSM9DS1.cpp
+++ b/Adafruit_LSM9DS1.cpp
@@ -301,7 +301,8 @@ void Adafruit_LSM9DS1::readTemp() {
     LSM9DS1_ACCELRANGE_8G, LSM9DS1_ACCELRANGE_16G
 */
 /**************************************************************************/
-void Adafruit_LSM9DS1::setupAccel(lsm9ds1AccelRange_t range, lsm9ds1AccelDataRate_t rate) {
+void Adafruit_LSM9DS1::setupAccel(lsm9ds1AccelRange_t range,
+                                  lsm9ds1AccelDataRate_t rate) {
   uint8_t reg = read8(XGTYPE, LSM9DS1_REGISTER_CTRL_REG6_XL);
   reg &= ~(0b11111000);
   reg |= range | rate;

--- a/Adafruit_LSM9DS1.cpp
+++ b/Adafruit_LSM9DS1.cpp
@@ -299,6 +299,9 @@ void Adafruit_LSM9DS1::readTemp() {
     @brief Configure the accelerometer ranging
     @param range Can be LSM9DS1_ACCELRANGE_2G, LSM9DS1_ACCELRANGE_4G,
     LSM9DS1_ACCELRANGE_8G, LSM9DS1_ACCELRANGE_16G
+    @param rate Can be LSM9DS1_ACCELDATARATE_10HZ, LSM9DS1_ACCELDATARATE_50HZ,
+    LSM9DS1_ACCELDATARATE_119HZ, LSM9DS1_ACCELDATARATE_238HZ,
+    LSM9DS1_ACCELDATARATE_476HZ, LSM9DS1_ACCELDATARATE_952HZ
 */
 /**************************************************************************/
 void Adafruit_LSM9DS1::setupAccel(lsm9ds1AccelRange_t range,

--- a/Adafruit_LSM9DS1.h
+++ b/Adafruit_LSM9DS1.h
@@ -108,20 +108,17 @@ public:
     LSM9DS1_ACCELRANGE_8G = (0b11 << 3),
   } lsm9ds1AccelRange_t;
 
-  /**! Enumeration for accelerometer data rage 3.125 - 1600 Hz */
+  /**! Enumeration for accelerometer data rate 10 - 952 Hz */
   typedef enum {
     LSM9DS1_ACCELDATARATE_POWERDOWN = (0b0000 << 4),
-    LSM9DS1_ACCELDATARATE_3_125HZ = (0b0001 << 4),
-    LSM9DS1_ACCELDATARATE_6_25HZ = (0b0010 << 4),
-    LSM9DS1_ACCELDATARATE_12_5HZ = (0b0011 << 4),
-    LSM9DS1_ACCELDATARATE_25HZ = (0b0100 << 4),
-    LSM9DS1_ACCELDATARATE_50HZ = (0b0101 << 4),
-    LSM9DS1_ACCELDATARATE_100HZ = (0b0110 << 4),
-    LSM9DS1_ACCELDATARATE_200HZ = (0b0111 << 4),
-    LSM9DS1_ACCELDATARATE_400HZ = (0b1000 << 4),
-    LSM9DS1_ACCELDATARATE_800HZ = (0b1001 << 4),
-    LSM9DS1_ACCELDATARATE_1600HZ = (0b1010 << 4)
-  } lm9ds1AccelDataRate_t;
+
+    LSM9DS1_ACCELDATARATE_10HZ = (0b001 << 5),
+    LSM9DS1_ACCELDATARATE_50HZ = (0b010 << 5),
+    LSM9DS1_ACCELDATARATE_119HZ = (0b011 << 5),
+    LSM9DS1_ACCELDATARATE_238HZ = (0b100 << 5),
+    LSM9DS1_ACCELDATARATE_476HZ = (0b101 << 5),
+    LSM9DS1_ACCELDATARATE_952HZ = (0b110 << 5),
+  } lsm9ds1AccelDataRate_t;
 
   /**! Enumeration for magnetometer scaling (4/8/12/16 gauss) */
   typedef enum {

--- a/Adafruit_LSM9DS1.h
+++ b/Adafruit_LSM9DS1.h
@@ -159,7 +159,7 @@ public:
   void readMag(void);
   void readTemp(void);
 
-  void setupAccel(lsm9ds1AccelRange_t range);
+  void setupAccel(lsm9ds1AccelRange_t range, lsm9ds1AccelDataRate_t rate);
   void setupMag(lsm9ds1MagGain_t gain);
   void setupGyro(lsm9ds1GyroScale_t scale);
 

--- a/examples/lsm9ds1/lsm9ds1.ino
+++ b/examples/lsm9ds1/lsm9ds1.ino
@@ -20,10 +20,10 @@ Adafruit_LSM9DS1 lsm = Adafruit_LSM9DS1();
 void setupSensor()
 {
   // 1.) Set the accelerometer range
-  lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_2G);
-  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_4G);
-  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_8G);
-  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_16G);
+  lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_2G, lsm.LSM9DS1_ACCELDATARATE_10HZ);
+  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_4G, lsm.LSM9DS1_ACCELDATARATE_119HZ);
+  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_8G, lsm.LSM9DS1_ACCELDATARATE_476HZ);
+  //lsm.setupAccel(lsm.LSM9DS1_ACCELRANGE_16G, lsm.LSM9DS1_ACCELDATARATE_952HZ);
   
   // 2.) Set the magnetometer sensitivity
   lsm.setupMag(lsm.LSM9DS1_MAGGAIN_4GAUSS);


### PR DESCRIPTION
- Updated the values of the enums that configure the accelerometer's data rate to reflect the values mentioned in the sensor's Datasheet. 

- `setupAccel()` now accepts a second parameter to configure the data rate of the accelerometer.

- Accelerometer is initialized to 10Hz refresh rate.