### PR TITLE
Fix wrong bit location for gyro scale setup

### DIFF
--- a/Adafruit_LSM9DS1.cpp
+++ b/Adafruit_LSM9DS1.cpp
@@ -312,7 +312,7 @@ void Adafruit_LSM9DS1::setupMag(lsm9ds1MagGain_t gain) {
 /**************************************************************************/
 void Adafruit_LSM9DS1::setupGyro(lsm9ds1GyroScale_t scale) {
   uint8_t reg = read8(XGTYPE, LSM9DS1_REGISTER_CTRL_REG1_G);
-  reg &= ~(0b00110000);
+  reg &= ~(0b00011000);
   reg |= scale;
   write8(XGTYPE, LSM9DS1_REGISTER_CTRL_REG1_G, reg);
 

--- a/Adafruit_LSM9DS1.h
+++ b/Adafruit_LSM9DS1.h
@@ -134,11 +134,11 @@ public:
   /**! Enumeration for gyroscope scaling (245/500/2000 dps) */
   typedef enum {
     LSM9DS1_GYROSCALE_245DPS =
-        (0b00 << 4), // +/- 245 degrees per second rotation
+        (0b00 << 3), // +/- 245 degrees per second rotation
     LSM9DS1_GYROSCALE_500DPS =
-        (0b01 << 4), // +/- 500 degrees per second rotation
+        (0b01 << 3), // +/- 500 degrees per second rotation
     LSM9DS1_GYROSCALE_2000DPS =
-        (0b11 << 4) // +/- 2000 degrees per second rotation
+        (0b11 << 3) // +/- 2000 degrees per second rotation
   } lsm9ds1GyroScale_t;
 
   /**! 3D floating point vector with X Y Z components */


### PR DESCRIPTION
Fixes #19 regarding the wrong bit location for gyro scale setup.
